### PR TITLE
Add support for `getAttribute` to `hasAttribute` transforms

### DIFF
--- a/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.input.js
@@ -1,0 +1,9 @@
+assert.equal(find('.foo').getAttribute('bar'), 'baz');
+
+assert.equal(find('.foo').getAttribute('bar'), 'baz', 'custom message');
+
+assert.equal(find('.foo', '.parent-scope').getAttribute('bar'), 'baz');
+
+assert.equal(find('.foo'), 'bar');
+
+assert.equal(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.output.js
@@ -1,0 +1,9 @@
+assert.dom('.foo').hasAttribute('bar', 'baz');
+
+assert.dom('.foo').hasAttribute('bar', 'baz', 'custom message');
+
+assert.dom('.foo', '.parent-scope').hasAttribute('bar', 'baz');
+
+assert.equal(find('.foo'), 'bar');
+
+assert.equal(true);


### PR DESCRIPTION
> jest

 PASS  __tests__/qunit-dom-codemod-test.js
  qunit-dom-codemod
    ✓ transforms correctly using "qunit-dom-codemod/checked" data (1797ms)
    ✓ transforms correctly using "qunit-dom-codemod/disabled" data (37ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-find-getattribute" data (14ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-find-length" data (41ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-find-text-trim" data (71ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-find-text" data (72ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-find-value" data (56ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-node-text-trim" data (10ms)
    ✓ transforms correctly using "qunit-dom-codemod/equal-node-text" data (10ms)
    ✓ transforms correctly using "qunit-dom-codemod/find-with-assert" data (7ms)
    ✓ transforms correctly using "qunit-dom-codemod/not-ok-find-classlist-contains" data (23ms)
    ✓ transforms correctly using "qunit-dom-codemod/not-ok-find" data (39ms)
    ✓ transforms correctly using "qunit-dom-codemod/not-ok-node-classlist-contains" data (13ms)
    ✓ transforms correctly using "qunit-dom-codemod/ok-find-classlist-contains" data (16ms)
    ✓ transforms correctly using "qunit-dom-codemod/ok-find" data (29ms)
    ✓ transforms correctly using "qunit-dom-codemod/ok-node-classlist-contains" data (10ms)
    ✓ transforms correctly using "qunit-dom-codemod/required" data (18ms)

Test Suites: 1 passed, 1 total
Tests:       17 passed, 17 total
Snapshots:   0 total
Time:        3.275s
Ran all test suites.