### PR TITLE
Use CommonJS instead of ES6 module

### DIFF
--- a/qunit-dom-codemod.js
+++ b/qunit-dom-codemod.js
@@ -28,7 +28,7 @@ const JQUERY_SELECTOR_EXTENSIONS = [
   ':visible',
 ];
 
-export default function(file, api, options) {
+module.exports = function(file, api, options) {
   const j = api.jscodeshift;
 
   const printOptions = options.printOptions || {quote: 'single'};


### PR DESCRIPTION
Resolves https://github.com/simplabs/qunit-dom-codemod/issues/43

It appears that the latest release of jscodeshift no longer supports ES6 modules when the transform is downloaded via HTTP. When using a local path the ES6 module format works fine though. 🤔 

/cc @kellyselden @fkling