### PR TITLE
package.json: Move `jscodeshift` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,11 @@
     "lint": "eslint .",
     "test": "jest"
   },
-  "dependencies": {
-    "jscodeshift": "^0.6.2"
-  },
   "devDependencies": {
     "babel-preset-env": "^1.7.0",
     "eslint": "^5.11.1",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "jscodeshift": "^0.6.2"
   },
   "engines": {
     "node": ">=6"


### PR DESCRIPTION
We only use this for testing, but not inside the transform itself.