### PR TITLE
Transform `assert.strictEqual()`

### DIFF
--- a/__testfixtures__/qunit-dom-codemod/checked.input.js
+++ b/__testfixtures__/qunit-dom-codemod/checked.input.js
@@ -1,15 +1,20 @@
 assert.ok(find('.foo').checked);
 assert.ok(find('.foo')[0].checked);
 assert.equal(find('.foo').checked, true);
+assert.strictEqual(find('.foo').checked, true);
 assert.notOk(find('.foo').checked);
 assert.notOk(find('.foo')[0].checked);
 assert.equal(find('.foo').checked, false);
+assert.strictEqual(find('.foo').checked, false);
 
 assert.ok(find('input[type=checkbox]', formDiv).is(':checked'), 'There is value in checkbox');
 assert.equal(find('input[type=checkbox]')[0].is(':checked'), false);
+assert.strictEqual(find('input[type=checkbox]')[0].is(':checked'), false);
 
 assert.ok(find('.checkbox-appointments input:checked'), 'Appointments checkbox is checked');
 assert.notOk(find('.checkbox-appointments input:checked'), 'Appointments checkbox is not checked');
 
 assert.equal(find('.checkbox-appointments input:checked').length, 0, 'Appointments checkbox is not checked');
+assert.strictEqual(find('.checkbox-appointments input:checked').length, 0, 'Appointments checkbox is not checked');
 assert.equal(find('.checkbox-appointments input:checked').length, 1, 'Appointments checkbox is checked');
+assert.strictEqual(find('.checkbox-appointments input:checked').length, 1, 'Appointments checkbox is checked');

--- a/__testfixtures__/qunit-dom-codemod/checked.output.js
+++ b/__testfixtures__/qunit-dom-codemod/checked.output.js
@@ -1,15 +1,20 @@
 assert.dom('.foo').isChecked();
 assert.dom('.foo').isChecked();
 assert.dom('.foo').isChecked();
+assert.dom('.foo').isChecked();
+assert.dom('.foo').isNotChecked();
 assert.dom('.foo').isNotChecked();
 assert.dom('.foo').isNotChecked();
 assert.dom('.foo').isNotChecked();
 
 assert.dom('input[type=checkbox]', formDiv).isChecked('There is value in checkbox');
 assert.dom('input[type=checkbox]').isNotChecked();
+assert.dom('input[type=checkbox]').isNotChecked();
 
 assert.dom('.checkbox-appointments input').isChecked('Appointments checkbox is checked');
 assert.dom('.checkbox-appointments input').isNotChecked('Appointments checkbox is not checked');
 
 assert.dom('.checkbox-appointments input').isNotChecked('Appointments checkbox is not checked');
+assert.dom('.checkbox-appointments input').isNotChecked('Appointments checkbox is not checked');
+assert.dom('.checkbox-appointments input').isChecked('Appointments checkbox is checked');
 assert.dom('.checkbox-appointments input').isChecked('Appointments checkbox is checked');

--- a/__testfixtures__/qunit-dom-codemod/disabled.input.js
+++ b/__testfixtures__/qunit-dom-codemod/disabled.input.js
@@ -1,15 +1,20 @@
 assert.ok(find('.foo').disabled);
 assert.ok(find('.foo')[0].disabled);
 assert.equal(find('.foo').disabled, true);
+assert.strictEqual(find('.foo').disabled, true);
 assert.notOk(find('.foo').disabled);
 assert.notOk(find('.foo')[0].disabled);
 assert.equal(find('.foo').disabled, false);
+assert.strictEqual(find('.foo').disabled, false);
 
 assert.ok(find('.foo', formDiv).is(':disabled'), 'custom message');
 assert.equal(find('.foo')[0].is(':disabled'), false);
+assert.strictEqual(find('.foo')[0].is(':disabled'), false);
 
 assert.ok(find('.foo:disabled'));
 assert.notOk(find('.foo:disabled'));
 
 assert.equal(find('.foo:disabled').length, 0);
+assert.strictEqual(find('.foo:disabled').length, 0);
 assert.equal(find('.foo:disabled').length, 1);
+assert.strictEqual(find('.foo:disabled').length, 1);

--- a/__testfixtures__/qunit-dom-codemod/disabled.output.js
+++ b/__testfixtures__/qunit-dom-codemod/disabled.output.js
@@ -1,15 +1,20 @@
 assert.dom('.foo').isDisabled();
 assert.dom('.foo').isDisabled();
 assert.dom('.foo').isDisabled();
+assert.dom('.foo').isDisabled();
+assert.dom('.foo').isNotDisabled();
 assert.dom('.foo').isNotDisabled();
 assert.dom('.foo').isNotDisabled();
 assert.dom('.foo').isNotDisabled();
 
 assert.dom('.foo', formDiv).isDisabled('custom message');
 assert.dom('.foo').isNotDisabled();
+assert.dom('.foo').isNotDisabled();
 
 assert.dom('.foo').isDisabled();
 assert.dom('.foo').isNotDisabled();
 
 assert.dom('.foo').isNotDisabled();
+assert.dom('.foo').isNotDisabled();
+assert.dom('.foo').isDisabled();
 assert.dom('.foo').isDisabled();

--- a/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.input.js
@@ -1,9 +1,14 @@
 assert.equal(find('.foo').getAttribute('bar'), 'baz');
+assert.strictEqual(find('.foo').getAttribute('bar'), 'baz');
 
 assert.equal(find('.foo').getAttribute('bar'), 'baz', 'custom message');
+assert.strictEqual(find('.foo').getAttribute('bar'), 'baz', 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').getAttribute('bar'), 'baz');
+assert.strictEqual(find('.foo', '.parent-scope').getAttribute('bar'), 'baz');
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-getattribute.output.js
@@ -1,9 +1,14 @@
 assert.dom('.foo').hasAttribute('bar', 'baz');
+assert.dom('.foo').hasAttribute('bar', 'baz');
 
+assert.dom('.foo').hasAttribute('bar', 'baz', 'custom message');
 assert.dom('.foo').hasAttribute('bar', 'baz', 'custom message');
 
 assert.dom('.foo', '.parent-scope').hasAttribute('bar', 'baz');
+assert.dom('.foo', '.parent-scope').hasAttribute('bar', 'baz');
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-length.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-length.input.js
@@ -1,23 +1,38 @@
 assert.equal(find('.foo').length, 0);
+assert.strictEqual(find('.foo').length, 0);
 assert.equal(find(foo).length, 0);
+assert.strictEqual(find(foo).length, 0);
 assert.equal(find(foo.bar).length, 0);
+assert.strictEqual(find(foo.bar).length, 0);
 assert.equal(findAll('.foo').length, 0);
+assert.strictEqual(findAll('.foo').length, 0);
 assert.equal(findAll(foo).length, 0);
+assert.strictEqual(findAll(foo).length, 0);
 assert.equal(findAll(foo.bar).length, 0);
+assert.strictEqual(findAll(foo.bar).length, 0);
 
 assert.equal(find('.foo').length, 0, 'custom message');
+assert.strictEqual(find('.foo').length, 0, 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').length, 0);
+assert.strictEqual(find('.foo', '.parent-scope').length, 0);
 
 assert.equal(find('input:first').length, 0);
+assert.strictEqual(find('input:first').length, 0);
 
 assert.equal(find('.foo').length, 2);
+assert.strictEqual(find('.foo').length, 2);
 assert.equal(findAll('.foo').length, 2);
+assert.strictEqual(findAll('.foo').length, 2);
 
 assert.equal(find('.foo').length, 2, 'custom message');
+assert.strictEqual(find('.foo').length, 2, 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').length, 2);
+assert.strictEqual(find('.foo', '.parent-scope').length, 2);
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-length.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-length.output.js
@@ -1,23 +1,38 @@
 assert.dom('.foo').doesNotExist();
-assert.dom(foo).doesNotExist();
-assert.dom(foo.bar).doesNotExist();
 assert.dom('.foo').doesNotExist();
 assert.dom(foo).doesNotExist();
+assert.dom(foo).doesNotExist();
+assert.dom(foo.bar).doesNotExist();
+assert.dom(foo.bar).doesNotExist();
+assert.dom('.foo').doesNotExist();
+assert.dom('.foo').doesNotExist();
+assert.dom(foo).doesNotExist();
+assert.dom(foo).doesNotExist();
+assert.dom(foo.bar).doesNotExist();
 assert.dom(foo.bar).doesNotExist();
 
 assert.dom('.foo').doesNotExist('custom message');
+assert.dom('.foo').doesNotExist('custom message');
 
+assert.dom('.foo', '.parent-scope').doesNotExist();
 assert.dom('.foo', '.parent-scope').doesNotExist();
 
 assert.equal(find('input:first').length, 0);
+assert.strictEqual(find('input:first').length, 0);
 
+assert.dom('.foo').exists({ count: 2 });
+assert.dom('.foo').exists({ count: 2 });
 assert.dom('.foo').exists({ count: 2 });
 assert.dom('.foo').exists({ count: 2 });
 
 assert.dom('.foo').exists({ count: 2 }, 'custom message');
+assert.dom('.foo').exists({ count: 2 }, 'custom message');
 
+assert.dom('.foo', '.parent-scope').exists({ count: 2 });
 assert.dom('.foo', '.parent-scope').exists({ count: 2 });
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-text-trim.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-text-trim.input.js
@@ -1,23 +1,38 @@
 assert.equal(find('.foo').textContent.trim(), 'bar');
+assert.strictEqual(find('.foo').textContent.trim(), 'bar');
 assert.equal(find('.foo').text().trim(), 'bar');
+assert.strictEqual(find('.foo').text().trim(), 'bar');
 
 assert.equal(find(foo).textContent.trim(), 'bar');
+assert.strictEqual(find(foo).textContent.trim(), 'bar');
 assert.equal(find(foo).text().trim(), 'bar');
+assert.strictEqual(find(foo).text().trim(), 'bar');
 
 assert.equal(find(foo.bar).textContent.trim(), 'bar');
+assert.strictEqual(find(foo.bar).textContent.trim(), 'bar');
 assert.equal(find(foo.bar).text().trim(), 'bar');
+assert.strictEqual(find(foo.bar).text().trim(), 'bar');
 
 assert.equal(find('.foo').textContent.trim(), 'bar', 'custom message');
+assert.strictEqual(find('.foo').textContent.trim(), 'bar', 'custom message');
 assert.equal(find('.foo').text().trim(), 'bar', 'custom message');
+assert.strictEqual(find('.foo').text().trim(), 'bar', 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').textContent.trim(), 'bar');
+assert.strictEqual(find('.foo', '.parent-scope').textContent.trim(), 'bar');
 assert.equal(find('.foo', '.parent-scope').text().trim(), 'bar');
+assert.strictEqual(find('.foo', '.parent-scope').text().trim(), 'bar');
 
 assert.equal(find('.foo').textContent.trim(), '  bar\n     baz   ');
+assert.strictEqual(find('.foo').textContent.trim(), '  bar\n     baz   ');
 assert.equal(find('.foo').text().trim(), '  bar\n     baz   ');
+assert.strictEqual(find('.foo').text().trim(), '  bar\n     baz   ');
 
 assert.equal(find('input:first').text().trim(), 'bar');
+assert.strictEqual(find('input:first').text().trim(), 'bar');
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-text-trim.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-text-trim.output.js
@@ -1,23 +1,38 @@
 assert.dom('.foo').hasText('bar');
 assert.dom('.foo').hasText('bar');
+assert.dom('.foo').hasText('bar');
+assert.dom('.foo').hasText('bar');
 
+assert.dom(foo).hasText('bar');
+assert.dom(foo).hasText('bar');
 assert.dom(foo).hasText('bar');
 assert.dom(foo).hasText('bar');
 
 assert.dom(foo.bar).hasText('bar');
 assert.dom(foo.bar).hasText('bar');
+assert.dom(foo.bar).hasText('bar');
+assert.dom(foo.bar).hasText('bar');
 
+assert.dom('.foo').hasText('bar', 'custom message');
+assert.dom('.foo').hasText('bar', 'custom message');
 assert.dom('.foo').hasText('bar', 'custom message');
 assert.dom('.foo').hasText('bar', 'custom message');
 
 assert.dom('.foo', '.parent-scope').hasText('bar');
 assert.dom('.foo', '.parent-scope').hasText('bar');
+assert.dom('.foo', '.parent-scope').hasText('bar');
+assert.dom('.foo', '.parent-scope').hasText('bar');
 
+assert.dom('.foo').hasText('bar baz');
+assert.dom('.foo').hasText('bar baz');
 assert.dom('.foo').hasText('bar baz');
 assert.dom('.foo').hasText('bar baz');
 
 assert.equal(find('input:first').text().trim(), 'bar');
+assert.strictEqual(find('input:first').text().trim(), 'bar');
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-text.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-text.input.js
@@ -1,27 +1,44 @@
 assert.equal(find('.foo').textContent, 'bar');
+assert.strictEqual(find('.foo').textContent, 'bar');
 assert.equal(find('.foo').text(), 'bar');
+assert.strictEqual(find('.foo').text(), 'bar');
 
 assert.equal(find(foo).textContent, 'bar');
+assert.strictEqual(find(foo).textContent, 'bar');
 assert.equal(find(foo).text(), 'bar');
+assert.strictEqual(find(foo).text(), 'bar');
 
 assert.equal(find(foo.bar).textContent, 'bar');
+assert.strictEqual(find(foo.bar).textContent, 'bar');
 assert.equal(find(foo.bar).text(), 'bar');
+assert.strictEqual(find(foo.bar).text(), 'bar');
 
 assert.equal(find('.foo').textContent, 'bar', 'custom message');
+assert.strictEqual(find('.foo').textContent, 'bar', 'custom message');
 assert.equal(find('.foo').text(), 'bar', 'custom message');
+assert.strictEqual(find('.foo').text(), 'bar', 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').textContent, 'bar');
+assert.strictEqual(find('.foo', '.parent-scope').textContent, 'bar');
 assert.equal(find('.foo', '.parent-scope').text(), 'bar');
+assert.strictEqual(find('.foo', '.parent-scope').text(), 'bar');
 
 assert.equal(find('.foo').textContent, '  bar\n     baz   ');
+assert.strictEqual(find('.foo').textContent, '  bar\n     baz   ');
 assert.equal(find('.foo').text(), '  bar\n     baz   ');
+assert.strictEqual(find('.foo').text(), '  bar\n     baz   ');
 
 assert.equal(find('input:first').text(), 'bar');
+assert.strictEqual(find('input:first').text(), 'bar');
 
 let bar = 'bar';
 assert.equal(find('.foo').textContent, bar);
+assert.strictEqual(find('.foo').textContent, bar);
 assert.equal(find('.foo').text(), bar);
+assert.strictEqual(find('.foo').text(), bar);
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-text.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-text.output.js
@@ -1,27 +1,44 @@
 assert.dom('.foo').hasText('bar');
 assert.dom('.foo').hasText('bar');
+assert.dom('.foo').hasText('bar');
+assert.dom('.foo').hasText('bar');
 
+assert.dom(foo).hasText('bar');
+assert.dom(foo).hasText('bar');
 assert.dom(foo).hasText('bar');
 assert.dom(foo).hasText('bar');
 
 assert.dom(foo.bar).hasText('bar');
 assert.dom(foo.bar).hasText('bar');
+assert.dom(foo.bar).hasText('bar');
+assert.dom(foo.bar).hasText('bar');
 
+assert.dom('.foo').hasText('bar', 'custom message');
+assert.dom('.foo').hasText('bar', 'custom message');
 assert.dom('.foo').hasText('bar', 'custom message');
 assert.dom('.foo').hasText('bar', 'custom message');
 
 assert.dom('.foo', '.parent-scope').hasText('bar');
 assert.dom('.foo', '.parent-scope').hasText('bar');
+assert.dom('.foo', '.parent-scope').hasText('bar');
+assert.dom('.foo', '.parent-scope').hasText('bar');
 
+assert.dom('.foo').hasText('bar baz');
+assert.dom('.foo').hasText('bar baz');
 assert.dom('.foo').hasText('bar baz');
 assert.dom('.foo').hasText('bar baz');
 
 assert.equal(find('input:first').text(), 'bar');
+assert.strictEqual(find('input:first').text(), 'bar');
 
 let bar = 'bar';
 assert.dom('.foo').hasText(bar);
 assert.dom('.foo').hasText(bar);
+assert.dom('.foo').hasText(bar);
+assert.dom('.foo').hasText(bar);
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-value.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-value.input.js
@@ -1,20 +1,33 @@
 assert.equal(find('.foo').value, 'bar');
+assert.strictEqual(find('.foo').value, 'bar');
 assert.equal(find('.foo').val(), 'bar');
+assert.strictEqual(find('.foo').val(), 'bar');
 
 assert.equal(find(foo).value, 'bar');
+assert.strictEqual(find(foo).value, 'bar');
 assert.equal(find(foo).val(), 'bar');
+assert.strictEqual(find(foo).val(), 'bar');
 
 assert.equal(find(foo.bar).value, 'bar');
+assert.strictEqual(find(foo.bar).value, 'bar');
 assert.equal(find(foo.bar).val(), 'bar');
+assert.strictEqual(find(foo.bar).val(), 'bar');
 
 assert.equal(find('.foo').value, 'bar', 'custom message');
+assert.strictEqual(find('.foo').value, 'bar', 'custom message');
 assert.equal(find('.foo').val(), 'bar', 'custom message');
+assert.strictEqual(find('.foo').val(), 'bar', 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').value, 'bar');
+assert.strictEqual(find('.foo', '.parent-scope').value, 'bar');
 assert.equal(find('.foo', '.parent-scope').val(), 'bar');
+assert.strictEqual(find('.foo', '.parent-scope').val(), 'bar');
 
 assert.equal(find('input:first').value, 'bar');
+assert.strictEqual(find('input:first').value, 'bar');
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-find-value.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-find-value.output.js
@@ -1,20 +1,33 @@
 assert.dom('.foo').hasValue('bar');
 assert.dom('.foo').hasValue('bar');
+assert.dom('.foo').hasValue('bar');
+assert.dom('.foo').hasValue('bar');
 
+assert.dom(foo).hasValue('bar');
+assert.dom(foo).hasValue('bar');
 assert.dom(foo).hasValue('bar');
 assert.dom(foo).hasValue('bar');
 
 assert.dom(foo.bar).hasValue('bar');
 assert.dom(foo.bar).hasValue('bar');
+assert.dom(foo.bar).hasValue('bar');
+assert.dom(foo.bar).hasValue('bar');
 
 assert.dom('.foo').hasValue('bar', 'custom message');
 assert.dom('.foo').hasValue('bar', 'custom message');
+assert.dom('.foo').hasValue('bar', 'custom message');
+assert.dom('.foo').hasValue('bar', 'custom message');
 
+assert.dom('.foo', '.parent-scope').hasValue('bar');
+assert.dom('.foo', '.parent-scope').hasValue('bar');
 assert.dom('.foo', '.parent-scope').hasValue('bar');
 assert.dom('.foo', '.parent-scope').hasValue('bar');
 
 assert.equal(find('input:first').value, 'bar');
+assert.strictEqual(find('input:first').value, 'bar');
 
 assert.equal(find('.foo'), 'bar');
+assert.strictEqual(find('.foo'), 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-node-text-trim.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-node-text-trim.input.js
@@ -1,9 +1,14 @@
 assert.equal(node.textContent.trim(), 'bar');
+assert.strictEqual(node.textContent.trim(), 'bar');
 
 assert.equal(node.textContent.trim(), 'bar', 'custom message');
+assert.strictEqual(node.textContent.trim(), 'bar', 'custom message');
 
 assert.equal(node.textContent.trim(), '  bar\n     baz   ');
+assert.strictEqual(node.textContent.trim(), '  bar\n     baz   ');
 
 assert.equal(node, 'bar');
+assert.strictEqual(node, 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-node-text-trim.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-node-text-trim.output.js
@@ -1,9 +1,14 @@
 assert.dom(node).hasText('bar');
+assert.dom(node).hasText('bar');
 
+assert.dom(node).hasText('bar', 'custom message');
 assert.dom(node).hasText('bar', 'custom message');
 
 assert.dom(node).hasText('bar baz');
+assert.dom(node).hasText('bar baz');
 
 assert.equal(node, 'bar');
+assert.strictEqual(node, 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-node-text.input.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-node-text.input.js
@@ -1,12 +1,18 @@
 assert.equal(node.textContent, 'bar');
+assert.strictEqual(node.textContent, 'bar');
 
 assert.equal(node.textContent, 'bar', 'custom message');
+assert.strictEqual(node.textContent, 'bar', 'custom message');
 
 assert.equal(node.textContent, '  bar\n     baz   ');
+assert.strictEqual(node.textContent, '  bar\n     baz   ');
 
 let bar = 'bar';
 assert.equal(node.textContent, bar);
+assert.strictEqual(node.textContent, bar);
 
 assert.equal(node, 'bar');
+assert.strictEqual(node, 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/equal-node-text.output.js
+++ b/__testfixtures__/qunit-dom-codemod/equal-node-text.output.js
@@ -1,12 +1,18 @@
 assert.dom(node).hasText('bar');
+assert.dom(node).hasText('bar');
 
 assert.dom(node).hasText('bar', 'custom message');
+assert.dom(node).hasText('bar', 'custom message');
 
+assert.dom(node).hasText('bar baz');
 assert.dom(node).hasText('bar baz');
 
 let bar = 'bar';
 assert.dom(node).hasText(bar);
+assert.dom(node).hasText(bar);
 
 assert.equal(node, 'bar');
+assert.strictEqual(node, 'bar');
 
 assert.equal(true);
+assert.strictEqual(true);

--- a/__testfixtures__/qunit-dom-codemod/not-ok-find-classlist-contains.input.js
+++ b/__testfixtures__/qunit-dom-codemod/not-ok-find-classlist-contains.input.js
@@ -9,7 +9,10 @@ assert.notOk(find('.foo').classList.contains('bar'), 'custom message');
 assert.notOk(find('.foo', '.parent-scope').classList.contains('bar'));
 
 assert.equal(find('.foo').classList.contains('bar'), false);
+assert.strictEqual(find('.foo').classList.contains('bar'), false);
 
 assert.equal(find('.foo').classList.contains('bar'), false, 'custom message');
+assert.strictEqual(find('.foo').classList.contains('bar'), false, 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').classList.contains('bar'), false);
+assert.strictEqual(find('.foo', '.parent-scope').classList.contains('bar'), false);

--- a/__testfixtures__/qunit-dom-codemod/not-ok-find-classlist-contains.output.js
+++ b/__testfixtures__/qunit-dom-codemod/not-ok-find-classlist-contains.output.js
@@ -9,7 +9,10 @@ assert.dom('.foo').hasNoClass('bar', 'custom message');
 assert.dom('.foo', '.parent-scope').hasNoClass('bar');
 
 assert.dom('.foo').hasNoClass('bar');
+assert.dom('.foo').hasNoClass('bar');
 
 assert.dom('.foo').hasNoClass('bar', 'custom message');
+assert.dom('.foo').hasNoClass('bar', 'custom message');
 
+assert.dom('.foo', '.parent-scope').hasNoClass('bar');
 assert.dom('.foo', '.parent-scope').hasNoClass('bar');

--- a/__testfixtures__/qunit-dom-codemod/not-ok-find.input.js
+++ b/__testfixtures__/qunit-dom-codemod/not-ok-find.input.js
@@ -10,14 +10,21 @@ assert.notOk(find('.foo', '.parent-scope'));
 assert.notOk(find('.foo', '.parent-scope')[0]);
 
 assert.equal(find('.foo'), false);
+assert.strictEqual(find('.foo'), false);
 assert.equal(find('.foo')[0], false);
+assert.strictEqual(find('.foo')[0], false);
 
 assert.equal(find('.foo'), false, 'custom message');
+assert.strictEqual(find('.foo'), false, 'custom message');
 assert.equal(find('.foo')[0], false, 'custom message');
+assert.strictEqual(find('.foo')[0], false, 'custom message');
 
 assert.equal(find('.foo', '.parent-scope'), false);
+assert.strictEqual(find('.foo', '.parent-scope'), false);
 assert.equal(find('.foo', '.parent-scope')[0], false);
+assert.strictEqual(find('.foo', '.parent-scope')[0], false);
 
 assert.equal(find('.foo'));
+assert.strictEqual(find('.foo'));
 
 assert.notOk(true);

--- a/__testfixtures__/qunit-dom-codemod/not-ok-find.output.js
+++ b/__testfixtures__/qunit-dom-codemod/not-ok-find.output.js
@@ -11,13 +11,20 @@ assert.dom('.foo', '.parent-scope').doesNotExist();
 
 assert.dom('.foo').doesNotExist();
 assert.dom('.foo').doesNotExist();
+assert.dom('.foo').doesNotExist();
+assert.dom('.foo').doesNotExist();
 
 assert.dom('.foo').doesNotExist('custom message');
 assert.dom('.foo').doesNotExist('custom message');
+assert.dom('.foo').doesNotExist('custom message');
+assert.dom('.foo').doesNotExist('custom message');
 
+assert.dom('.foo', '.parent-scope').doesNotExist();
+assert.dom('.foo', '.parent-scope').doesNotExist();
 assert.dom('.foo', '.parent-scope').doesNotExist();
 assert.dom('.foo', '.parent-scope').doesNotExist();
 
 assert.equal(find('.foo'));
+assert.strictEqual(find('.foo'));
 
 assert.notOk(true);

--- a/__testfixtures__/qunit-dom-codemod/not-ok-node-classlist-contains.input.js
+++ b/__testfixtures__/qunit-dom-codemod/not-ok-node-classlist-contains.input.js
@@ -5,5 +5,7 @@ assert.notOk(node.classList.contains('bar'));
 assert.notOk(node.classList.contains('bar'), 'custom message');
 
 assert.equal(node.classList.contains('bar'), false);
+assert.strictEqual(node.classList.contains('bar'), false);
 
 assert.equal(node.classList.contains('bar'), false, 'custom message');
+assert.strictEqual(node.classList.contains('bar'), false, 'custom message');

--- a/__testfixtures__/qunit-dom-codemod/not-ok-node-classlist-contains.output.js
+++ b/__testfixtures__/qunit-dom-codemod/not-ok-node-classlist-contains.output.js
@@ -5,5 +5,7 @@ assert.dom(node).hasNoClass('bar');
 assert.dom(node).hasNoClass('bar', 'custom message');
 
 assert.dom(node).hasNoClass('bar');
+assert.dom(node).hasNoClass('bar');
 
+assert.dom(node).hasNoClass('bar', 'custom message');
 assert.dom(node).hasNoClass('bar', 'custom message');

--- a/__testfixtures__/qunit-dom-codemod/ok-find-classlist-contains.input.js
+++ b/__testfixtures__/qunit-dom-codemod/ok-find-classlist-contains.input.js
@@ -9,7 +9,10 @@ assert.ok(find('.foo').classList.contains('bar'), 'custom message');
 assert.ok(find('.foo', '.parent-scope').classList.contains('bar'));
 
 assert.equal(find('.foo').classList.contains('bar'), true);
+assert.strictEqual(find('.foo').classList.contains('bar'), true);
 
 assert.equal(find('.foo').classList.contains('bar'), true, 'custom message');
+assert.strictEqual(find('.foo').classList.contains('bar'), true, 'custom message');
 
 assert.equal(find('.foo', '.parent-scope').classList.contains('bar'), true);
+assert.strictEqual(find('.foo', '.parent-scope').classList.contains('bar'), true);

--- a/__testfixtures__/qunit-dom-codemod/ok-find-classlist-contains.output.js
+++ b/__testfixtures__/qunit-dom-codemod/ok-find-classlist-contains.output.js
@@ -9,7 +9,10 @@ assert.dom('.foo').hasClass('bar', 'custom message');
 assert.dom('.foo', '.parent-scope').hasClass('bar');
 
 assert.dom('.foo').hasClass('bar');
+assert.dom('.foo').hasClass('bar');
 
 assert.dom('.foo').hasClass('bar', 'custom message');
+assert.dom('.foo').hasClass('bar', 'custom message');
 
+assert.dom('.foo', '.parent-scope').hasClass('bar');
 assert.dom('.foo', '.parent-scope').hasClass('bar');

--- a/__testfixtures__/qunit-dom-codemod/ok-find.input.js
+++ b/__testfixtures__/qunit-dom-codemod/ok-find.input.js
@@ -13,16 +13,24 @@ assert.ok(find('input:first'));
 assert.ok(find('input:contains(foo)'));
 
 assert.equal(find('.foo'), true);
+assert.strictEqual(find('.foo'), true);
 assert.equal(find('.foo')[0], true);
+assert.strictEqual(find('.foo')[0], true);
 
 assert.equal(find('.foo'), true, 'custom message');
+assert.strictEqual(find('.foo'), true, 'custom message');
 assert.equal(find('.foo')[0], true, 'custom message');
+assert.strictEqual(find('.foo')[0], true, 'custom message');
 
 assert.equal(find('.foo', '.parent-scope'), true);
+assert.strictEqual(find('.foo', '.parent-scope'), true);
 assert.equal(find('.foo', '.parent-scope')[0], true);
+assert.strictEqual(find('.foo', '.parent-scope')[0], true);
 
 assert.equal(find('.foo'));
+assert.strictEqual(find('.foo'));
 
 assert.ok(true);
 
 assert.equal(foo(), true);
+assert.strictEqual(foo(), true);

--- a/__testfixtures__/qunit-dom-codemod/ok-find.output.js
+++ b/__testfixtures__/qunit-dom-codemod/ok-find.output.js
@@ -14,15 +14,23 @@ assert.ok(find('input:contains(foo)'));
 
 assert.dom('.foo').exists();
 assert.dom('.foo').exists();
+assert.dom('.foo').exists();
+assert.dom('.foo').exists();
 
 assert.dom('.foo').exists('custom message');
 assert.dom('.foo').exists('custom message');
+assert.dom('.foo').exists('custom message');
+assert.dom('.foo').exists('custom message');
 
+assert.dom('.foo', '.parent-scope').exists();
+assert.dom('.foo', '.parent-scope').exists();
 assert.dom('.foo', '.parent-scope').exists();
 assert.dom('.foo', '.parent-scope').exists();
 
 assert.equal(find('.foo'));
+assert.strictEqual(find('.foo'));
 
 assert.ok(true);
 
 assert.equal(foo(), true);
+assert.strictEqual(foo(), true);

--- a/__testfixtures__/qunit-dom-codemod/ok-node-classlist-contains.input.js
+++ b/__testfixtures__/qunit-dom-codemod/ok-node-classlist-contains.input.js
@@ -5,5 +5,7 @@ assert.ok(node.classList.contains('bar'));
 assert.ok(node.classList.contains('bar'), 'custom message');
 
 assert.equal(node.classList.contains('bar'), true);
+assert.strictEqual(node.classList.contains('bar'), true);
 
 assert.equal(node.classList.contains('bar'), true, 'custom message');
+assert.strictEqual(node.classList.contains('bar'), true, 'custom message');

--- a/__testfixtures__/qunit-dom-codemod/ok-node-classlist-contains.output.js
+++ b/__testfixtures__/qunit-dom-codemod/ok-node-classlist-contains.output.js
@@ -5,5 +5,7 @@ assert.dom(node).hasClass('bar');
 assert.dom(node).hasClass('bar', 'custom message');
 
 assert.dom(node).hasClass('bar');
+assert.dom(node).hasClass('bar');
 
+assert.dom(node).hasClass('bar', 'custom message');
 assert.dom(node).hasClass('bar', 'custom message');

--- a/__testfixtures__/qunit-dom-codemod/required.input.js
+++ b/__testfixtures__/qunit-dom-codemod/required.input.js
@@ -3,15 +3,20 @@ assert.ok(find(foo).required);
 assert.ok(find(foo.bar).required);
 assert.ok(find('.foo')[0].required);
 assert.equal(find('.foo').required, true);
+assert.strictEqual(find('.foo').required, true);
 assert.notOk(find('.foo').required);
 assert.notOk(find('.foo')[0].required);
 assert.equal(find('.foo').required, false);
+assert.strictEqual(find('.foo').required, false);
 
 assert.ok(find('.foo', formDiv).is(':required'), 'custom message');
 assert.equal(find('.foo')[0].is(':required'), false);
+assert.strictEqual(find('.foo')[0].is(':required'), false);
 
 assert.ok(find('.foo:required'));
 assert.notOk(find('.foo:required'));
 
 assert.equal(find('.foo:required').length, 0);
+assert.strictEqual(find('.foo:required').length, 0);
 assert.equal(find('.foo:required').length, 1);
+assert.strictEqual(find('.foo:required').length, 1);

--- a/__testfixtures__/qunit-dom-codemod/required.output.js
+++ b/__testfixtures__/qunit-dom-codemod/required.output.js
@@ -3,15 +3,20 @@ assert.dom(foo).isRequired();
 assert.dom(foo.bar).isRequired();
 assert.dom('.foo').isRequired();
 assert.dom('.foo').isRequired();
+assert.dom('.foo').isRequired();
+assert.dom('.foo').isNotRequired();
 assert.dom('.foo').isNotRequired();
 assert.dom('.foo').isNotRequired();
 assert.dom('.foo').isNotRequired();
 
 assert.dom('.foo', formDiv).isRequired('custom message');
 assert.dom('.foo').isNotRequired();
+assert.dom('.foo').isNotRequired();
 
 assert.dom('.foo').isRequired();
 assert.dom('.foo').isNotRequired();
 
 assert.dom('.foo').isNotRequired();
+assert.dom('.foo').isNotRequired();
+assert.dom('.foo').isRequired();
 assert.dom('.foo').isRequired();


### PR DESCRIPTION
Closes #144 by adding support for transforming [`assert.strictEqual()`](https://api.qunitjs.com/assert/strictEqual/). Adjusted all of the testcases accordingly.